### PR TITLE
WIP - Adding base_create method

### DIFF
--- a/lib/fhir_client/ext/model.rb
+++ b/lib/fhir_client/ext/model.rb
@@ -61,6 +61,10 @@ module FHIR
       handle_response client.conditional_create(model, params)
     end
 
+    def self.base_create(resource, options, format)
+      handle_response client.base_create(self, options, format)
+    end
+
     def self.partial_update(id, patchset, options = {})
       handle_response client.partial_update(self, id, patchset, options = {})
     end


### PR DESCRIPTION
Nous avons besoin de cet ajout pour utiliser simplement le create FHIR avec les headers que l'on souhaite. 
  